### PR TITLE
Phase 3 — CSS-necessity migration (theme.css) [#94]

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -1,6 +1,11 @@
 /*
- * Wicked Evolutions — Theme Effects v0.3.1
- * Effects-only CSS. Layout via theme.json + editor settings.
+ * Wicked Evolutions — Theme Effects (v0.4 / Phase 3 — CSS-necessity)
+ * Target: effects-only. Remaining non-effect rules are explicitly deferred and
+ * classified in docs/architecture/phase-3-css-necessity-map.md:
+ *   - light/dark [data-theme] token redefinition           -> #97 (Phase 4)
+ *   - .we-content-col width / wideSize                      -> #95 (content-width)
+ *   - component visual systems (badges/callouts/chips/etc.) -> v0.5 phase 6 (block styles)
+ * Layout constants live in theme.json (e.g. --wp--custom--layout--sticky-top).
  */
 
 /* ═══ GLOBAL ═══ */
@@ -38,18 +43,15 @@ a { text-decoration: none; transition: color 0.2s; }
 @media (max-width: 768px) { .we-tabstrip { display: none; } }
 
 /* ═══ 3-COLUMN DOCS LAYOUT ═══ */
-main.we-has-sticky-columns { padding-top: 0; }
-main.we-has-sticky-columns .we-content-col { padding-top: var(--wp--preset--spacing--50); }
-.we-page-columns { margin: 0 !important; padding: 0 !important; gap: 0 !important; }
-:where(.wp-block-columns).we-page-columns { margin-bottom: 0 !important; }
+.we-page-columns { margin: 0; padding: 0; gap: 0; }
 .we-page-columns .wp-block-post-title, .we-page-columns h1 { font-size: clamp(1.7rem, 3vw, 2.4rem) !important; line-height: 1.08; }
 .wp-block-post-content .wp-block-table { overflow-x: auto; -webkit-overflow-scrolling: touch; }
-.we-sidebar-col { position: sticky !important; top: 112px !important; align-self: flex-start !important; max-height: calc(100vh - 112px); overflow-y: auto; border-right: 1px solid var(--wp--custom--border--subtle); padding: 20px 0 48px 0 !important; margin: 0 !important; }
+.we-sidebar-col { position: sticky; top: var(--wp--custom--layout--sticky-top); align-self: flex-start; max-height: calc(100vh - var(--wp--custom--layout--sticky-top)); overflow-y: auto; border-right: 1px solid var(--wp--custom--border--subtle); padding: 20px 0 48px 0; margin: 0; }
 .we-sidebar-col::-webkit-scrollbar { width: 3px; }
 .we-sidebar-col::-webkit-scrollbar-track { background: transparent; }
 .we-sidebar-col::-webkit-scrollbar-thumb { background: var(--wp--custom--border--subtle); border-radius: 3px; }
 .wp-block-columns.we-page-columns > .wp-block-column.we-content-col { flex-basis: 800px !important; max-width: 800px !important; flex-grow: 0 !important; padding: 20px 48px 80px !important; }
-.we-toc-rail { position: sticky !important; top: 112px !important; align-self: flex-start !important; max-height: calc(100vh - 112px); overflow-y: auto; font-family: var(--wp--preset--font-family--syne); padding: 20px 24px 48px 32px !important; }
+.we-toc-rail { position: sticky; top: var(--wp--custom--layout--sticky-top); align-self: flex-start; max-height: calc(100vh - var(--wp--custom--layout--sticky-top)); overflow-y: auto; font-family: var(--wp--preset--font-family--syne); padding: 20px 24px 48px 32px; }
 .we-toc-rail::before { content: "On this page"; font-size: 0.6875rem; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--wp--preset--color--muted); display: block; margin-bottom: 0.75rem; font-family: var(--wp--preset--font-family--jetbrains-mono); }
 .we-toc-list { list-style: none; padding: 0; margin: 0; }
 .we-toc-item a { font-size: 0.8125rem; font-weight: 500; color: var(--wp--preset--color--muted); display: block; padding: 0.25rem 0 0.25rem 0.75rem; border-left: 1px solid var(--wp--custom--border--subtle); transition: color 0.15s, border-color 0.15s; line-height: 1.4; text-decoration: none; }
@@ -65,7 +67,7 @@ main.we-has-sticky-columns .we-content-col { padding-top: var(--wp--preset--spac
 .we-toc-rail::-webkit-scrollbar { width: 3px; }
 .we-toc-rail::-webkit-scrollbar-track { background: transparent; }
 .we-toc-rail::-webkit-scrollbar-thumb { background: var(--wp--custom--border--subtle); border-radius: 3px; }
-.admin-bar .we-sidebar-col, .admin-bar .we-toc-rail { top: calc(112px + 32px) !important; }
+.admin-bar .we-sidebar-col, .admin-bar .we-toc-rail { top: calc(var(--wp--custom--layout--sticky-top) + 32px) !important; }
 .we-site-knowledge .wp-block-post-content p, .we-site-knowledge .wp-block-post-content li, .we-site-knowledge .wp-block-post-content blockquote { font-family: var(--wp--preset--font-family--spectral); font-weight: 400; line-height: 1.72; }
 
 /* ═══ SIDEBAR ═══ */
@@ -240,7 +242,7 @@ main.we-has-sticky-columns .we-content-col { padding-top: var(--wp--preset--spac
 /* ═══ RESPONSIVE ═══ */
 .we-toc-mobile { display: none; }
 @media (max-width: 1280px) {
-  .we-toc-rail { display: none !important; }
+  .we-toc-rail { display: none; }
   .we-toc-mobile { display: block; margin-bottom: 1.5rem; }
   .we-toc-mobile .we-toc-toggle { display: flex; }
   .we-toc-mobile .we-toc-list { display: none; margin-top: 0.75rem; }
@@ -248,7 +250,7 @@ main.we-has-sticky-columns .we-content-col { padding-top: var(--wp--preset--spac
   .wp-block-columns.we-page-columns > .wp-block-column.we-content-col { max-width: none !important; flex-grow: 1 !important; flex-basis: auto !important; padding: 20px 24px 80px !important; }
 }
 @media (max-width: 1024px) {
-  .we-sidebar-col { display: none !important; }
+  .we-sidebar-col { display: none; }
   .wp-block-columns.we-page-columns > .wp-block-column.we-content-col { padding: 20px 16px 48px !important; }
   .blog-post-cards { grid-template-columns: repeat(2, 1fr) !important; }
 }

--- a/docs/architecture/phase-3-css-necessity-map.md
+++ b/docs/architecture/phase-3-css-necessity-map.md
@@ -47,6 +47,29 @@ gate for #94 is therefore:
 
 **Result:** `!important` 30 → 24 lines (15 occurrences removed); file integrity preserved (braces balanced). The remaining 24 are all justified below.
 
+### Tokenization scope — precise (sticky offset is *not yet* fully source-canonical)
+
+The token canonicalizes the **CSS-level** sticky offset only. To be exact about where `112px`
+still lives and why parity nonetheless holds:
+
+| Source of the sticky `top` | After this phase | Canonical to the token? |
+|---|---|---|
+| `theme.css` `.we-sidebar-col` / `.we-toc-rail` `top` + `max-height` calcs | `var(--wp--custom--layout--sticky-top)` | **yes** |
+| `theme.css` `.admin-bar …` offset | `calc(var(--…--sticky-top) + 32px)` (kept `!important`) | **yes** |
+| **Saved block markup** — `position.top:"112px"` on the toc column in `templates/single-post.html:89` **and** `templates/category.html:74` | **unchanged `112px` literal** | **no — deferred** |
+
+So `.we-sidebar-col` (no `position` attr → CSS-driven) and the admin-bar calc are fully
+token-driven, while the **toc rail's base `top`** is still a serialized **block-support**
+`112px` in two templates. WordPress's position support can inject that as an inline
+`top:112px` at render, which is exactly why the `.admin-bar` rule **keeps `!important`** (to
+beat that injected inline). Parity is therefore preserved — the literal and the token are the
+same value — but the toc-rail base `top` is **parity-safe, not yet source-canonical**.
+
+These two template literals are **intentionally left** for the block-attribute lift (§7):
+changing block-support serialization needs editor/render validation (block-validation risk)
+and can't be confirmed under the deploy-gate. They are *not* a missed tokenization — they are
+the one place the constant can only be promoted once the lift is verifiable.
+
 ## 4. Per-section classification (every rule region)
 
 | `theme.css` section | Bucket | Native home | Status / owning phase |

--- a/docs/architecture/phase-3-css-necessity-map.md
+++ b/docs/architecture/phase-3-css-necessity-map.md
@@ -1,0 +1,129 @@
+# Phase 3 — CSS-necessity map (`assets/css/theme.css`)
+
+> **Phase 3 of the v0.4 native foundation** (roadmap §5.3 — CSS into the authority ladder).
+> **Issue:** #94 · **Branch:** `v0.4-css-necessity` · **Date:** 2026-06-02.
+> **Scope (orchestrator-approved, banded 1A/2A):** classify every `theme.css` rule by
+> responsibility; migrate the in-band layout decisions up the ladder; tokenize the repeated
+> sticky constant; normalize token references; confirm FluentCart is out; deliver this map.
+> Component visual systems, light/dark, and content-width are **explicitly deferred** to
+> their owning phases (named per row below) — not removed this phase.
+>
+> Read against [`AGENTS.md`](../../AGENTS.md) §1 (authority ladder) and the
+> [`native-authority-spec.md`](native-authority-spec.md) decision inventory (rows 6, 13, 14, 16).
+
+---
+
+## 1. Restated acceptance (per orchestrator, 2026-06-02)
+
+`theme.css` cannot be **100% effects-only** this phase while the deferred bands stand. The
+gate for #94 is therefore:
+
+1. the **in-scope band complete** (layout `!important` reduced by fixing the level; sticky
+   constant tokenized; references normalized; FluentCart confirmed out), and
+2. **parity-verified** (no visual change), and
+3. `theme.css` reduced to **effects + the explicitly-deferred bands**, with
+4. this **classified map** naming each deferred rule's native home + owning phase.
+
+## 2. Responsibility buckets
+
+| Bucket | Meaning | Disposition this phase |
+|---|---|---|
+| **effect** | transitions, `backdrop-filter`, `::selection`, scrollbars, hover/transform, smooth-scroll | **keep** in `theme.css` (its correct tier-9 home) |
+| **layout-override** | the 3-column docs grid: sizing, sticky, padding | **in-band** — `!important` removed by fixing the level; constant tokenized; remainder is clean tier-9 layout (block-attribute lift is a verify-gated follow-up, §6) |
+| **token-value** | hard-coded constant a preset/custom-prop should own | **in-band** — the `112px` sticky offset promoted to `theme.json` |
+| **component visual system** | badges, callouts, chips, cards, stats, ability-table, nav skins | **deferred → v0.5 phase 6** (register as block styles; audit row 16) |
+| **light/dark token redefinition** | `[data-theme]` blocks re-declaring `--wp--preset--*` | **deferred → #97 / Phase 4** (rows 8/9; gated) |
+| **content-width** | `.we-content-col` width / `wideSize` | **deferred → #95 / Phase 4** |
+| **plugin-integration** | FluentCart / WooCommerce CSS | **n/a — none in the base stylesheet** (§5) |
+
+## 3. What changed this phase
+
+| # | Change | Lines (new file) | Why parity-safe |
+|---|---|---|---|
+| 1 | **Tokenize sticky offset.** Added `settings.custom.layout.stickyTop = "112px"` → `--wp--custom--layout--sticky-top`; replaced the three CSS literals + the `calc(100vh - 112px)` / `calc(112px + 32px)` expressions with the token. | `theme.json:97`; `theme.css:49,54,70` | Same computed value — pure `var()` substitution. |
+| 2 | **Remove dead code.** Deleted the two `main.we-has-sticky-columns …` rules — the class is applied by **no** template/part (only referenced in CSS). | (removed) | Selector never matched → no render effect. |
+| 3 | **Drop superfluous `!important` (fix the level, don't escalate).** `.we-page-columns` margin/padding/gap; `.we-sidebar-col` and `.we-toc-rail` position/top/align-self/padding/margin; the redundant `:where(.wp-block-columns).we-page-columns{margin-bottom}`; the responsive `.we-toc-rail`/`.we-sidebar-col { display:none }`. | `theme.css:46,49,54,243,251` | These only beat 0-specificity `:where()` core defaults or same-spec-earlier rules; the column `<div>`s carry **only** `flex-basis` inline and these columns declare no spacing/align attrs, so nothing competes. `!important` was superfluous. |
+| 4 | **Header comment** rewritten to state the effects-only target + the deferred bands + the token. | `theme.css:1-9` | comment only |
+
+**Result:** `!important` 30 → 24 lines (15 occurrences removed); file integrity preserved (braces balanced). The remaining 24 are all justified below.
+
+## 4. Per-section classification (every rule region)
+
+| `theme.css` section | Bucket | Native home | Status / owning phase |
+|---|---|---|---|
+| GLOBAL: smooth-scroll, antialias, `body` transition, `::selection`, `a` transition, `.wp-block-code` overflow | **effect** | tier 9 | **keep** |
+| GLOBAL: post-content `strong`/`em` color, inline `code` chip | component (typography) | tier 2/5 | v0.5 (small; or `styles.blocks`) |
+| HEADER: `backdrop-filter`, `z-index`, all `:hover`/transitions, theme-toggle button | **effect** | tier 9 | **keep** |
+| HEADER: site-title dot, `we-version-badge`, `we-tab*`, `we-nav-topbar/tabstrip*` skins | component (nav) | block styles | **v0.5 phase 6** |
+| HEADER: `.we-icon-moon/-sun` toggle visibility | light/dark | variation/global-styles | **#97 / Phase 4** |
+| 3-COL LAYOUT: `.we-page-columns`, `.we-sidebar-col`, `.we-toc-rail` sizing/sticky/padding | **layout-override** | block layout attrs (tier 1) + `theme.json` (tier 2) | **this phase** — `!important` removed, `112px` tokenized; per-column block-attribute lift = verify-gated follow-up (§6) |
+| 3-COL LAYOUT: `.we-content-col` `flex-basis/max-width:800px` + responsive | **content-width** | `theme.json` layout / block width | **#95 / Phase 4** (left byte-identical) |
+| 3-COL LAYOUT: `.we-page-columns … h1` clamp `!important` | layout/typography (contextual) | block style / per-block setting | **kept** (defensive contextual override; v0.5 candidate) |
+| 3-COL LAYOUT: `.we-site-knowledge … p/li/blockquote { spectral }` | token/typography (install scoping) | knowledge **variation** (tier 3) vs body-class | **review** — variation-vs-body-class boundary (touches the Phase-2/activation question); left as-is |
+| SIDEBAR, CATEGORY BADGES, BLOG, CALLOUTS, RULED/EYEBROW, STEP LIST, LANE/ABILITY CHIPS, SIDEBAR SEARCH/DOTS, FILTER CHIPS, CARD HOVER, QUICK-LINK/RELATED, STATS BAR, ABILITY TABLE | **component visual system** | block style variations + scoped block CSS | **v0.5 phase 6** (audit row 16) — appearance kept; `:hover`/transition halves are legit effects |
+| DOCS category-row `:hover` | **effect** | tier 9 | **keep** |
+| LIGHT MODE / DARK MODE (`[data-theme]` blocks) | **light/dark token redefinition** | style variation / global styles (tier 3) | **#97 / Phase 4** (headline; gated — untouched) |
+| RESPONSIVE: `.we-toc-rail`/`.we-sidebar-col { display:none }` | layout-override | media + block | **this phase** — `!important` dropped |
+| RESPONSIVE: `.we-content-col` padding/width | content-width | `theme.json` / block | **#95 / Phase 4** (kept) |
+| RESPONSIVE: `.blog-post-cards` grid | component (blog) | block layout (query grid) | **v0.5** (kept; beats the query block's inline grid) |
+
+### The 24 remaining `!important`, each justified
+
+- **Nav/sidebar/component hovers + skins** (`we-topbar/we-tab/we-tabstrip` hover; `we-sidebar p/title/label`; `we-sidebar` active; `blog-post-card` hover; archive-row hover; `we-callout*` padding; `we-cat-dot a`): **component band (v0.5)** — most beat core-block inline styles; removed when these become block styles.
+- **`.we-page-columns … h1` clamp:** defensive contextual typography (kept).
+- **`.we-content-col` (×2 incl. responsive):** **content-width (#95)** — left byte-identical.
+- **`.admin-bar … { top }`:** genuinely required — must beat the toc-rail's block-support-**injected** inline `top` (position support is active; confirmed by `is-position-sticky` in the live render).
+- **`.blog-post-cards` grid (×2):** beats the query block's inline grid (component/blog band).
+- **`[data-theme] … .we-header` / sidebar active (×3):** **light/dark (#97)** — untouched.
+
+## 5. FluentCart
+
+`grep -rin 'fluent|fct|woocommerce|checkout' assets/css/` → **none**. The base stylesheet
+contains **no** plugin-integration CSS, so "scope FluentCart out" needs no source change. The
+FluentCart contrast work referenced by earlier audits lived on a separate/uncommitted branch
+(per `native-authority-spec.md` §3.6) and never landed in base `theme.css`. If it returns, its
+native home is a **conditionally-enqueued / scoped integration stylesheet**, not base
+`theme.css`.
+
+## 6. Reference-form normalization (folded in)
+
+The target was to converge token references toward native slug-binding where a block should
+bind a token, keeping raw `var()` only where genuinely CSS-level. Findings:
+
+- **Templates/parts are already convergent.** Color/font bindings use slug attributes
+  (`textColor`/`backgroundColor`/`fontFamily`, normalized to roles in Phase 2); other style
+  props use the native `var:preset|…` / `var:custom|…` shorthand. Repo-wide grep finds
+  **zero** raw `var(--wp--…)` and **zero** hardcoded hex/rgba in template **attribute** JSON.
+  (The raw `var()` that exist are CSS-level in `theme.css` — correct — and auto-serialized
+  inline HTML — not hand-authored.) → **no edits needed; documented as convergent.**
+- **`theme.css` keeps raw `var()`** — correct for the CSS tier. A separate, parity-neutral
+  cleanup could align CSS name-slug refs (`--…--syne`, `--…--yellow`) to the Phase-2 role
+  slugs (`--…--heading`, `--…--accent-1`); deferred as cosmetic to avoid a large diff this
+  phase.
+
+## 7. The deferred block-attribute lift (verify-gated)
+
+Row 13's ideal end state moves the 3-column **sizing/sticky/padding** out of `theme.css`
+into per-column **block attributes** (tier 1) + `theme.json` (tier 2). This phase promoted
+the constant (tier 2) and removed the specificity escalation, leaving clean tier-9 layout
+rules. The remaining lift — writing the block-support serialization into the column blocks so
+the CSS rules can be deleted — is **not done blind**: it requires editor/render validation to
+serialize the supports byte-exactly (else block-validation breaks), which cannot be confirmed
+under the deploy-gate (live is v0.3.1; changes are undeployed). It is the concrete next action
+once a deploy-preview or Playground pass is authorized.
+
+## 8. Parity verification
+
+- **JSON + CSS integrity:** `theme.json` parses; `theme.css` braces balanced (188/188); no
+  stray `112px` literal remains in CSS.
+- **By construction:** every change is value-preserving — token substitution (same value) or
+  removal of `!important` that only beat 0-specificity `:where()` defaults / same-spec-earlier
+  rules, against columns whose only inline style is `flex-basis` (verified by reading the saved
+  `<div>`s). Dead-code removal targeted a class no template applies.
+- **Abilities (read-only):** `themes/design-snapshot` baseline captured (deployed v0.3.1);
+  `content/render-page` baseline captured. Position support confirmed active in the live render
+  (`is-position-sticky`), which grounds the `!important` analysis above.
+- **Deploy-gated:** the *effective* before/after `render-page` diff on the changed CSS requires
+  a deploy (no live mutation this phase) — same gate as Phase 2. Until then parity rests on the
+  by-construction argument; the post-deploy `design-snapshot` + `render-page` compare is the
+  follow-up gate.

--- a/theme.json
+++ b/theme.json
@@ -93,7 +93,8 @@
             "border": { "subtle": "rgba(255,255,255,0.055)", "default": "rgba(255,255,255,0.08)", "strong": "rgba(255,255,255,0.11)" },
             "lineHeight": { "tight": "1.03", "heading": "1.12", "body": "1.82", "loose": "1.9" },
             "letterSpacing": { "tight": "-0.045em", "heading": "-0.03em", "label": "0.1em" },
-            "radius": { "card": "8px", "segment": "12px", "terminal": "14px", "pill": "100px" }
+            "radius": { "card": "8px", "segment": "12px", "terminal": "14px", "pill": "100px" },
+            "layout": { "stickyTop": "112px" }
         }
     },
     "styles": {


### PR DESCRIPTION
Banded Phase 3 (orchestrator-approved 1A/2A) of the v0.4 native foundation. Resolves the in-scope band of #94; the literal "100% effects-only" gate was restated (deferred bands named below).

## What changed
- **Tokenized the sticky offset** → `settings.custom.layout.stickyTop` (`--wp--custom--layout--sticky-top`); CSS now sources it (was `112px` literal ×3 + `calc` exprs). `theme.json` + `theme.css`.
- **Cut superfluous layout `!important`** (fix the level, don't escalate): `.we-page-columns` margin/padding/gap, the sidebar/toc columns' position/top/align-self/padding/margin, and the responsive `display:none`. These only beat 0-specificity `:where()` core defaults / same-spec-earlier rules; the columns carry only `flex-basis` inline and declare no spacing/align attrs → value-preserving. **`!important` 30 → 24 lines.**
- **Removed dead code**: `main.we-has-sticky-columns …` (class applied by no template).
- **Restated the `theme.css` header** + delivered the **classified rule map** (`docs/architecture/phase-3-css-necessity-map.md`) naming every rule's bucket + native home + owning phase.

## Confirmed / no-op
- **FluentCart**: none in `assets/css/` — "scope out" needs no change.
- **Reference forms**: templates already convergent (slug + `var:preset|`; zero raw `var()`/hex in attribute JSON) → documented, no edits.

## Deferred (left untouched, per 2A) — each documented in the map
- light/dark `[data-theme]` token redefinition → **#97 / Phase 4**
- `.we-content-col` 800px width + `wideSize` → **#95 / Phase 4** (left byte-identical)
- component visual systems (badges/callouts/chips/cards/stats/table/nav skins) → **v0.5 phase 6** (block styles)

## Parity
Value-preserving by construction (token substitution + removal of `!important` that beat 0-spec defaults, against columns whose only inline is `flex-basis`). `theme.json` parses; `theme.css` braces balanced; no stray `112px`. Baseline `design-snapshot` + `render-page` captured (live v0.3.1); position support confirmed active (`is-position-sticky`), grounding the `!important` analysis. ⚠️ Effective before/after `render-page` diff is **deploy-gated** (no live mutation this phase) — same gate as Phase 2.

## Not done (verify-gated, noted in map §7)
Lifting the cleaned layout rules further into per-column **block attributes** (deleting the CSS) needs editor/render validation to serialize block supports byte-exactly — can't be confirmed blind under the deploy-gate. Concrete next action once a deploy-preview/Playground pass is authorized.

Draft — for Hermes/GPT-5.5 review. Don't merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
