### PR TITLE
Phase 3 follow-up — sticky-top lift: proven impossible (docs) [#94]

### DIFF
--- a/docs/architecture/phase-3-css-necessity-map.md
+++ b/docs/architecture/phase-3-css-necessity-map.md
@@ -138,8 +138,7 @@ piece into Playground and **proved it impossible**: **`core/column` does not sup
 sticky**, so the column's `position` attribute is inert in every value form — there is no
 block-support serialization to write, and the CSS is necessarily the canonical source (already
 tokenized). See [`phase-3-sticky-top-lift-finding.md`](phase-3-sticky-top-lift-finding.md).
-(The broader padding/sizing lift is moot for the same reason — these columns expose no native
-position/spacing support that would let CSS be deleted; `we-content-col` width remains #95.)
+(The sticky-position piece is resolved as impossible for `core/column`; this finding does not settle the separate content-width / padding / sizing questions. `we-content-col` width remains #95, and any non-position layout cleanup should stay in its owning follow-up.)
 
 ## 8. Parity verification
 

--- a/docs/architecture/phase-3-css-necessity-map.md
+++ b/docs/architecture/phase-3-css-necessity-map.md
@@ -56,19 +56,25 @@ still lives and why parity nonetheless holds:
 |---|---|---|
 | `theme.css` `.we-sidebar-col` / `.we-toc-rail` `top` + `max-height` calcs | `var(--wp--custom--layout--sticky-top)` | **yes** |
 | `theme.css` `.admin-bar …` offset | `calc(var(--…--sticky-top) + 32px)` (kept `!important`) | **yes** |
-| **Saved block markup** — `position.top:"112px"` on the toc column in `templates/single-post.html:89` **and** `templates/category.html:74` | **unchanged `112px` literal** | **no — deferred** |
+| **Saved block markup** — `position.top:"112px"` on the toc column in `templates/single-post.html:89` **and** `templates/category.html:74` | **unchanged `112px` literal** | **n/a — inert** (see correction below) |
 
-So `.we-sidebar-col` (no `position` attr → CSS-driven) and the admin-bar calc are fully
-token-driven, while the **toc rail's base `top`** is still a serialized **block-support**
-`112px` in two templates. WordPress's position support can inject that as an inline
-`top:112px` at render, which is exactly why the `.admin-bar` rule **keeps `!important`** (to
-beat that injected inline). Parity is therefore preserved — the literal and the token are the
-same value — but the toc-rail base `top` is **parity-safe, not yet source-canonical**.
+> **Correction (2026-06-02, `v0.4-sticky-top-lift`, Playground-proven).** An earlier draft of
+> this note assumed the toc-rail `position.top:"112px"` is a live **block-support** value that
+> WordPress can inject as inline `top` — and that the `.admin-bar !important` exists to beat
+> that injection. **That is wrong.** Playground (WP 7.0) proves **`core/column` does not
+> support position sticky at all**, so the `position` attribute on these columns is **wholly
+> inert** (no `is-position-sticky`, no `position`/`top` rendered, in any value form). The
+> sticky behavior is **entirely CSS-driven** and already tokenized; the two literals are inert
+> metadata, never a serialization source. The `.admin-bar` `!important` is therefore
+> **superfluous** (the `.admin-bar .we-toc-rail` selector already out-specifies the base rule),
+> not "required to beat an injection." Full proof + decision in
+> [`phase-3-sticky-top-lift-finding.md`](phase-3-sticky-top-lift-finding.md).
 
-These two template literals are **intentionally left** for the block-attribute lift (§7):
-changing block-support serialization needs editor/render validation (block-validation risk)
-and can't be confirmed under the deploy-gate. They are *not* a missed tokenization — they are
-the one place the constant can only be promoted once the lift is verifiable.
+So `.we-sidebar-col` / `.we-toc-rail` `top` and the admin-bar calc are fully token-driven via
+CSS. The two template `position.top:"112px"` literals are **left as-is** (per that follow-up's
+task) but are **inert** — the CSS token is the sole canonical source. The block-attribute
+"lift" that §7 anticipated is **resolved as impossible** (column has no position support), not
+deferred.
 
 ## 4. Per-section classification (every rule region)
 
@@ -95,7 +101,7 @@ the one place the constant can only be promoted once the lift is verifiable.
 - **Nav/sidebar/component hovers + skins** (`we-topbar/we-tab/we-tabstrip` hover; `we-sidebar p/title/label`; `we-sidebar` active; `blog-post-card` hover; archive-row hover; `we-callout*` padding; `we-cat-dot a`): **component band (v0.5)** — most beat core-block inline styles; removed when these become block styles.
 - **`.we-page-columns … h1` clamp:** defensive contextual typography (kept).
 - **`.we-content-col` (×2 incl. responsive):** **content-width (#95)** — left byte-identical.
-- **`.admin-bar … { top }`:** genuinely required — must beat the toc-rail's block-support-**injected** inline `top` (position support is active; confirmed by `is-position-sticky` in the live render).
+- **`.admin-bar … { top }`:** kept this phase, but **superfluous** (corrected — see §3 note + [`phase-3-sticky-top-lift-finding.md`](phase-3-sticky-top-lift-finding.md)): `core/column` has no position support, so there is no injected inline `top` to beat; `.admin-bar .we-toc-rail` (0,2,0) already out-specifies the base `.we-toc-rail` (0,1,0). Harmless; a candidate to drop in the optional follow-up cleanup.
 - **`.blog-post-cards` grid (×2):** beats the query block's inline grid (component/blog band).
 - **`[data-theme] … .we-header` / sidebar active (×3):** **light/dark (#97)** — untouched.
 
@@ -124,16 +130,16 @@ bind a token, keeping raw `var()` only where genuinely CSS-level. Findings:
   slugs (`--…--heading`, `--…--accent-1`); deferred as cosmetic to avoid a large diff this
   phase.
 
-## 7. The deferred block-attribute lift (verify-gated)
+## 7. The block-attribute lift — RESOLVED: not possible for these columns
 
-Row 13's ideal end state moves the 3-column **sizing/sticky/padding** out of `theme.css`
-into per-column **block attributes** (tier 1) + `theme.json` (tier 2). This phase promoted
-the constant (tier 2) and removed the specificity escalation, leaving clean tier-9 layout
-rules. The remaining lift — writing the block-support serialization into the column blocks so
-the CSS rules can be deleted — is **not done blind**: it requires editor/render validation to
-serialize the supports byte-exactly (else block-validation breaks), which cannot be confirmed
-under the deploy-gate (live is v0.3.1; changes are undeployed). It is the concrete next action
-once a deploy-preview or Playground pass is authorized.
+Row 13's ideal end state would move the 3-column **sizing/sticky** out of `theme.css` into
+per-column **block attributes**. The follow-up slice `v0.4-sticky-top-lift` took the sticky
+piece into Playground and **proved it impossible**: **`core/column` does not support position
+sticky**, so the column's `position` attribute is inert in every value form — there is no
+block-support serialization to write, and the CSS is necessarily the canonical source (already
+tokenized). See [`phase-3-sticky-top-lift-finding.md`](phase-3-sticky-top-lift-finding.md).
+(The broader padding/sizing lift is moot for the same reason — these columns expose no native
+position/spacing support that would let CSS be deleted; `we-content-col` width remains #95.)
 
 ## 8. Parity verification
 
@@ -144,8 +150,10 @@ once a deploy-preview or Playground pass is authorized.
   rules, against columns whose only inline style is `flex-basis` (verified by reading the saved
   `<div>`s). Dead-code removal targeted a class no template applies.
 - **Abilities (read-only):** `themes/design-snapshot` baseline captured (deployed v0.3.1);
-  `content/render-page` baseline captured. Position support confirmed active in the live render
-  (`is-position-sticky`), which grounds the `!important` analysis above.
+  `content/render-page` baseline captured. The live render shows `is-position-sticky` — but
+  follow-up Playground proof (§7) established that comes from the **header Group**, not the
+  layout columns (`core/column` has no position support). The corrected `!important` analysis
+  is in §3/§4 + [`phase-3-sticky-top-lift-finding.md`](phase-3-sticky-top-lift-finding.md).
 - **Deploy-gated:** the *effective* before/after `render-page` diff on the changed CSS requires
   a deploy (no live mutation this phase) — same gate as Phase 2. Until then parity rests on the
   by-construction argument; the post-deploy `design-snapshot` + `render-page` compare is the

--- a/docs/architecture/phase-3-sticky-top-lift-finding.md
+++ b/docs/architecture/phase-3-sticky-top-lift-finding.md
@@ -1,0 +1,114 @@
+# Phase 3 follow-up — sticky-top block-attribute lift: finding
+
+> **Branch:** `v0.4-sticky-top-lift` · **Date:** 2026-06-02 · Follows the merged Phase 3 (#94).
+> **Outcome:** **NO canonicalization** — proven in Playground. The two saved
+> `position.top:"112px"` block-attribute literals are **inert** (their block doesn't support
+> position), so they are **left as-is** and the **CSS `--wp--custom--layout--sticky-top`
+> token is the canonical source**. This is the task's documented "NO" branch — an acceptable
+> outcome, not a failure. **No source/CSS/template bytes changed; docs only.**
+
+---
+
+## 1. The question
+
+Phase 3 tokenized the CSS sticky offset but left two saved block-attribute literals
+(`templates/single-post.html:89`, `templates/category.html:74`):
+
+```html
+<!-- wp:column {"width":"240px","style":{"position":{"type":"sticky","top":"112px"}}, …} -->
+```
+
+Can `position.top` be canonicalized to the token — e.g. `"top":"var:custom|layout|sticky-top"`
+(→ `var(--wp--custom--layout--sticky-top)`) — and still validate + render identically?
+
+## 2. Handbook finding (mcp-obsidian "Wordpress Developers Handbooks")
+
+`Theme Handbook/.../Settings/Position.md` documents **only** `settings.position.sticky`
+(the UI toggle) and states the control appears "for blocks that support the position feature,
+**such as Group**." Column is **not** listed. The `var:custom|…|…` shorthand is documented
+**only** for `theme.json` **styles** (style-engine context — `Settings/Custom.md`,
+`Styles/Using Presets.md`), never for block-level position. Two signals: (a) Column may not
+support position at all; (b) there is no documented token form for `position.top`.
+
+## 3. Playground proof (decisive)
+
+`@wp-playground/cli` (WP 7.0, PHP 8.3), theme auto-mounted + active. Rendered `core/column`
+and `core/group` (the known position-supporting control) across all three `top` forms via
+`do_blocks()`:
+
+```
+column supports position?  false
+group  supports position?  true
+sticky-top token resolves in stylesheet?  YES (112px)
+
+COLUMN literal    -> <div class="wp-block-column t is-layout-flow …" style="flex-basis:240px">
+COLUMN rawvar     -> <div class="wp-block-column t is-layout-flow …" style="flex-basis:240px">
+COLUMN shorthand  -> <div class="wp-block-column t is-layout-flow …" style="flex-basis:240px">
+GROUP  literal    -> <div class="wp-block-group … wp-container-1 is-position-sticky">
+GROUP  rawvar     -> <div class="wp-block-group … wp-container-2 is-position-sticky">
+GROUP  shorthand  -> <div class="wp-block-group … wp-container-3 is-position-sticky">
+```
+
+**`core/column` does not support position sticky.** Its `position` attribute is **wholly
+inert** — literal, raw `var()`, and `var:custom|` shorthand all produce the **identical**
+position-less `<div>` (no `is-position-sticky`, no `position`, no `top`). `core/group` (the
+control) *does* support it and emits a scoped `wp-container-N` rule, confirming the mechanism
+works and the test is valid.
+
+**Front-end render (real `single-post.html`, `http://…/?p=1`, HTTP 200):**
+
+- `.we-sidebar-col` / `.we-toc-rail` columns render `style="flex-basis:…"` **only** — no
+  `is-position-sticky`, no `position`/`top`. (The page's 3 `is-position-sticky` are the
+  **header Group**, which legitimately supports position.)
+- Served `theme.css` is the merged tokenized Phase-3 file
+  (`.we-toc-rail { position: sticky; top: var(--wp--custom--layout--sticky-top); … }`).
+- `--wp--custom--layout--sticky-top: 112px` resolves in the inline global styles.
+- The page is valid (HTTP 200, layout assembles) → the inert `position` attr causes no
+  block-validation error.
+
+## 4. Decision (task "NO" branch)
+
+The lift is **not possible via the token** — but for a more fundamental reason than the task
+anticipated ("`position.top` takes a literal length"): **`core/column` doesn't support
+position at all**, so *no* value (token or literal) on `position.top` is honored. The sticky
+behavior is, and always was, **CSS-driven** — already tokenized in Phase 3.
+
+Per the task: **leave the hardcoded values, document the constraint, CSS token is canonical.**
+Done — no source change. The two literals are inert metadata in the saved markup; they are not
+a serialization source.
+
+## 5. Verification against the task's checklist
+
+| Required check | Result |
+|---|---|
+| sticky sidebar + TOC behavior | CSS-driven; `.we-sidebar-col`/`.we-toc-rail` ship `position:sticky; top:var(--…--sticky-top)`; token resolves to `112px` (Playground). |
+| admin-bar offset (`+32px`) | `.admin-bar .we-{sidebar-col,toc-rail}{ top: calc(var(--…--sticky-top) + 32px) }` → `144px`; token resolves. |
+| no block-validation breakage | Column ignores the `position` attr; saved `<div>` (flex-basis only) == serialized output → valid (front end HTTP 200; isolated `do_blocks` clean). |
+| no visual regression | **No change made** — literals left untouched, CSS unchanged → regression impossible. |
+
+## 6. Corrections to the merged Phase-3 map
+
+This finding **falsifies two claims** in `phase-3-css-necessity-map.md` (now corrected there,
+pointing here):
+
+1. The map said the `.admin-bar` `!important` is "required to beat the toc-rail's
+   block-support-**injected** inline `top`." **There is no injection** — column doesn't
+   support position. The `.admin-bar .we-toc-rail` selector (0,2,0) beats the base
+   `.we-toc-rail` (0,1,0) on specificity alone, so that `!important` is **superfluous (but
+   harmless)**, not "genuinely required."
+2. The map listed the two literals as "deferred to the block-attribute lift." That lift is
+   now **resolved as impossible**; they are inert, and the CSS token is canonical.
+
+## 7. Recommended optional cleanup (NOT done here — needs orchestrator OK)
+
+Two parity-neutral, Playground-verifiable tidy-ups, deliberately left out of this slice (the
+task said *leave* the literals):
+
+- **Remove the inert `position` attr** from the two toc columns (`single-post.html:89`,
+  `category.html:74`). Proven safe: the column already serializes to `flex-basis`-only, so
+  removing the ignored attr changes nothing rendered and removes misleading dead metadata.
+- **Drop the now-superfluous `!important`** on `.admin-bar .we-{sidebar-col,toc-rail}` (it
+  wins on specificity without it).
+
+Both are tiny and I can verify them in the same Playground harness if approved. Left as a
+follow-up so this slice stays a faithful "document + leave" per the task.


### PR DESCRIPTION
Phase 3 follow-up requested by reviewer + orchestrator: try to canonicalize the two saved `position.top:"112px"` block-attribute literals to the `--wp--custom--layout--sticky-top` token, **iff** WordPress block serialization accepts it safely. Verified with the **wp-playground** workflow (no live deploy).

## Native question → answered NO (and more fundamentally than anticipated)

**Handbook** (`Settings/Position.md`): documents only `settings.position.sticky`; the control appears "for blocks that support the position feature, **such as Group**" — Column not listed. `var:custom|…` is documented only for theme.json **styles**, never block-level position.

**Playground proof (WP 7.0, theme active):**
```
column supports position?  false      group supports position?  true
sticky-top token resolves?  YES (112px)
COLUMN literal / rawvar / shorthand  -> identical: <div class="wp-block-column …" style="flex-basis:240px">   (no is-position-sticky, no position/top)
GROUP  literal / rawvar / shorthand  -> wp-container-N is-position-sticky   (control: mechanism works)
```
→ **`core/column` has no position support**, so the column `position.top` attr is **wholly inert** in every value form. The sticky is **CSS-driven** (already tokenized in Phase 3). Real `single-post.html` front-end render (HTTP 200) confirms: toc-rail/sidebar-col columns are `flex-basis`-only, served `theme.css` is the tokenized file, token resolves to `112px`, page is valid.

## Outcome (task NO-branch) — docs only, no source change
- **Left** both literals as-is; the CSS token is the canonical source.
- New `docs/architecture/phase-3-sticky-top-lift-finding.md` records Handbook + Playground proof + decision + the task verification checklist.
- **Corrected** the merged Phase-3 map: the `.admin-bar top !important` is **not** beating an injected inline `top` (there's no injection) — it's **superfluous but harmless** (out-specifies the base rule); and the "deferred block-attribute lift" is **resolved as impossible**, not pending.

## Verification (task checklist)
sticky sidebar+TOC ✓ (CSS, token=112px) · admin-bar `+32px` ✓ (calc resolves) · block validation ✓ (column ignores attr; HTTP 200) · visual regression ✓ none (no change made).

## Recommended optional follow-up (NOT done — needs your OK)
Two parity-neutral, Playground-verifiable tidy-ups left out to keep this a faithful "document + leave": (1) remove the inert `position` attr from the two toc columns; (2) drop the now-superfluous `.admin-bar` `!important`. Say the word and I'll do + verify them.

Draft — for Hermes/GPT-5.5. Don't merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
