### PR TITLE
Sticky cleanup — remove proven-dead position metadata + superfluous !important

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -67,7 +67,7 @@ a { text-decoration: none; transition: color 0.2s; }
 .we-toc-rail::-webkit-scrollbar { width: 3px; }
 .we-toc-rail::-webkit-scrollbar-track { background: transparent; }
 .we-toc-rail::-webkit-scrollbar-thumb { background: var(--wp--custom--border--subtle); border-radius: 3px; }
-.admin-bar .we-sidebar-col, .admin-bar .we-toc-rail { top: calc(var(--wp--custom--layout--sticky-top) + 32px) !important; }
+.admin-bar .we-sidebar-col, .admin-bar .we-toc-rail { top: calc(var(--wp--custom--layout--sticky-top) + 32px); }
 .we-site-knowledge .wp-block-post-content p, .we-site-knowledge .wp-block-post-content li, .we-site-knowledge .wp-block-post-content blockquote { font-family: var(--wp--preset--font-family--spectral); font-weight: 400; line-height: 1.72; }
 
 /* ═══ SIDEBAR ═══ */

--- a/templates/category.html
+++ b/templates/category.html
@@ -71,7 +71,7 @@
 </div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"240px","style":{"position":{"type":"sticky","top":"112px"}}} -->
+<!-- wp:column {"width":"240px"} -->
 <div class="wp-block-column" style="flex-basis:240px">
 
 <!-- wp:heading {"level":4,"style":{"typography":{"fontSize":"0.6875rem","fontWeight":"700","letterSpacing":"0.1em","textTransform":"uppercase"}},"textColor":"muted","fontFamily":"mono"} -->

--- a/templates/single-post.html
+++ b/templates/single-post.html
@@ -86,7 +86,7 @@
 </div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"240px","style":{"position":{"type":"sticky","top":"112px"}},"className":"we-toc-rail"} -->
+<!-- wp:column {"width":"240px","className":"we-toc-rail"} -->
 <div class="wp-block-column we-toc-rail" style="flex-basis:240px">
 <!-- wp:pattern {"slug":"wickedevolutions/toc"} /-->
 </div>


### PR DESCRIPTION
Tiny, parity-neutral cleanup recommended by the #101 review. Acts on what #101 **proved** (in Playground): `core/column` has no position support, so the toc columns' `position` attribute is inert and the `.admin-bar` sticky `!important` is superfluous. Kept separate; Phase 4 (#95/#97) and v0.5 stay out.

## Changes (3 edits, 2 small commits)
- **Remove inert `position` attr** from the toc columns — `single-post.html:89`, `category.html:74` (`position.top:"112px"` that `core/column` ignores).
- **Drop the superfluous `!important`** on `.admin-bar .we-sidebar-col, .admin-bar .we-toc-rail { top: … }` — the `.admin-bar .we-toc-rail` selector (0,2,0) already out-specifies the base rule (0,1,0).

## Parity — Playground-verified (same harness as #101, no deploy)
Rendered the **edited** `single-post.html` (`/?p=1`, WP 7.0):
- Render is **byte-identical** to the #101 pre-edit render (**64462b** both) → zero visual change.
- toc-rail/sidebar-col/content-col `<div>`s unchanged (flex-basis only); column `is-position-sticky` = **0** (attr was inert); header `is-position-sticky` = **3** → sticky header still works.
- Served `theme.css`: sticky rules intact; admin-bar rule present **without** `!important` (count 0).
- Page valid (HTTP 200); block still validates — `save()` for `{width,className}` matches the saved `<div>` (the removed attr was always ignored by `save()`).

## Task checklist
sticky sidebar+TOC ✓ (CSS unchanged) · admin-bar `+32px` ✓ (rule present, specificity-correct) · block validation ✓ (identical render, save() matches) · no visual regression ✓ (byte-identical).

Draft — for Hermes/GPT-5.5. Don't merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
