### PR TITLE
Phase 4 (slice 1) — content-width 832, single-sourced + editable [#95]

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -3,7 +3,8 @@
  * Target: effects-only. Remaining non-effect rules are explicitly deferred and
  * classified in docs/architecture/phase-3-css-necessity-map.md:
  *   - light/dark [data-theme] token redefinition           -> #97 (Phase 4)
- *   - .we-content-col width / wideSize                      -> #95 (content-width)
+ *   - .we-content-col fixed width                          -> resolved by #103 (content-col fills; theme.json contentSize governs)
+ *   - docs band wideSize / remaining layout constants      -> #95 follow-up / design pass
  *   - component visual systems (badges/callouts/chips/etc.) -> v0.5 phase 6 (block styles)
  * Layout constants live in theme.json (e.g. --wp--custom--layout--sticky-top).
  */

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -44,14 +44,21 @@ a { text-decoration: none; transition: color 0.2s; }
 @media (max-width: 768px) { .we-tabstrip { display: none; } }
 
 /* ═══ 3-COLUMN DOCS LAYOUT ═══ */
-.we-page-columns { margin: 0; padding: 0; gap: 0; }
+/* The docs band width tracks theme.json contentSize, so the centred 3-col band has no slack
+   (no TOC-edge gap) and the Site Editor content-width control governs the middle column.
+   Per-template overhead is the fixed chrome around the content column:
+   3-col = sidebar 261 (incl 1px border) + toc 296 (incl padding) + content padding 96 = 653;
+   2-col = sidebar 261 + content padding 96 = 357. */
+.we-page-columns { max-width: 100%; margin-left: auto; margin-right: auto; padding: 0; gap: 0; }
+.we-page-columns--3col { width: calc(653px + var(--wp--style--global--content-size)); }
+.we-page-columns--2col { width: calc(357px + var(--wp--style--global--content-size)); }
 .we-page-columns .wp-block-post-title, .we-page-columns h1 { font-size: clamp(1.7rem, 3vw, 2.4rem) !important; line-height: 1.08; }
 .wp-block-post-content .wp-block-table { overflow-x: auto; -webkit-overflow-scrolling: touch; }
 .we-sidebar-col { position: sticky; top: var(--wp--custom--layout--sticky-top); align-self: flex-start; max-height: calc(100vh - var(--wp--custom--layout--sticky-top)); overflow-y: auto; border-right: 1px solid var(--wp--custom--border--subtle); padding: 20px 0 48px 0; margin: 0; }
 .we-sidebar-col::-webkit-scrollbar { width: 3px; }
 .we-sidebar-col::-webkit-scrollbar-track { background: transparent; }
 .we-sidebar-col::-webkit-scrollbar-thumb { background: var(--wp--custom--border--subtle); border-radius: 3px; }
-.wp-block-columns.we-page-columns > .wp-block-column.we-content-col { padding: 20px 48px 80px; }
+.wp-block-columns.we-page-columns > .wp-block-column.we-content-col { flex-basis: var(--wp--style--global--content-size); max-width: var(--wp--style--global--content-size); flex-grow: 0; padding: 20px 48px 80px; }
 .we-toc-rail { position: sticky; top: var(--wp--custom--layout--sticky-top); align-self: flex-start; max-height: calc(100vh - var(--wp--custom--layout--sticky-top)); overflow-y: auto; font-family: var(--wp--preset--font-family--syne); padding: 20px 24px 48px 32px; }
 .we-toc-rail::before { content: "On this page"; font-size: 0.6875rem; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--wp--preset--color--muted); display: block; margin-bottom: 0.75rem; font-family: var(--wp--preset--font-family--jetbrains-mono); }
 .we-toc-list { list-style: none; padding: 0; margin: 0; }

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -50,7 +50,7 @@ a { text-decoration: none; transition: color 0.2s; }
 .we-sidebar-col::-webkit-scrollbar { width: 3px; }
 .we-sidebar-col::-webkit-scrollbar-track { background: transparent; }
 .we-sidebar-col::-webkit-scrollbar-thumb { background: var(--wp--custom--border--subtle); border-radius: 3px; }
-.wp-block-columns.we-page-columns > .wp-block-column.we-content-col { flex-basis: 800px !important; max-width: 800px !important; flex-grow: 0 !important; padding: 20px 48px 80px !important; }
+.wp-block-columns.we-page-columns > .wp-block-column.we-content-col { padding: 20px 48px 80px; }
 .we-toc-rail { position: sticky; top: var(--wp--custom--layout--sticky-top); align-self: flex-start; max-height: calc(100vh - var(--wp--custom--layout--sticky-top)); overflow-y: auto; font-family: var(--wp--preset--font-family--syne); padding: 20px 24px 48px 32px; }
 .we-toc-rail::before { content: "On this page"; font-size: 0.6875rem; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; color: var(--wp--preset--color--muted); display: block; margin-bottom: 0.75rem; font-family: var(--wp--preset--font-family--jetbrains-mono); }
 .we-toc-list { list-style: none; padding: 0; margin: 0; }

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -3,7 +3,7 @@
  * Target: effects-only. Remaining non-effect rules are explicitly deferred and
  * classified in docs/architecture/phase-3-css-necessity-map.md:
  *   - light/dark [data-theme] token redefinition           -> #97 (Phase 4)
- *   - .we-content-col fixed width                          -> resolved by #103 (content-col fills; theme.json contentSize governs)
+ *   - .we-content-col fixed width                          -> resolved by #103 (content column tracks theme.json contentSize via --wp--style--global--content-size; hardcoded 800px removed)
  *   - docs band wideSize / remaining layout constants      -> #95 follow-up / design pass
  *   - component visual systems (badges/callouts/chips/etc.) -> v0.5 phase 6 (block styles)
  * Layout constants live in theme.json (e.g. --wp--custom--layout--sticky-top).
@@ -44,14 +44,16 @@ a { text-decoration: none; transition: color 0.2s; }
 @media (max-width: 768px) { .we-tabstrip { display: none; } }
 
 /* ═══ 3-COLUMN DOCS LAYOUT ═══ */
-/* The docs band width tracks theme.json contentSize, so the centred 3-col band has no slack
-   (no TOC-edge gap) and the Site Editor content-width control governs the middle column.
-   Per-template overhead is the fixed chrome around the content column:
-   3-col = sidebar 261 (incl 1px border) + toc 296 (incl padding) + content padding 96 = 653;
-   2-col = sidebar 261 + content padding 96 = 357. */
+/* The docs band width tracks theme.json contentSize, so the centred band has no slack (no TOC-edge
+   gap) and the Site Editor content-width control governs the middle column. The fixed "chrome"
+   around the content column is promoted to theme.json (settings.custom.layout.docsBandChrome*):
+     653 = sidebar 261 (incl 1px border) + toc 296 (incl padding) + content padding 96   (3-col)
+     357 = sidebar 261 + content padding 96                                              (2-col, no toc)
+   Keep these in sync with the markup column widths until the primitive token model lands
+   (#95 follow-up: sidebar/TOC/padding as tokens, widths off markup, band derived). */
 .we-page-columns { max-width: 100%; margin-left: auto; margin-right: auto; padding: 0; gap: 0; }
-.we-page-columns--3col { width: calc(653px + var(--wp--style--global--content-size)); }
-.we-page-columns--2col { width: calc(357px + var(--wp--style--global--content-size)); }
+.we-page-columns--3col { width: calc(var(--wp--custom--layout--docs-band-chrome-3-col) + var(--wp--style--global--content-size)); }
+.we-page-columns--2col { width: calc(var(--wp--custom--layout--docs-band-chrome-2-col) + var(--wp--style--global--content-size)); }
 .we-page-columns .wp-block-post-title, .we-page-columns h1 { font-size: clamp(1.7rem, 3vw, 2.4rem) !important; line-height: 1.08; }
 .wp-block-post-content .wp-block-table { overflow-x: auto; -webkit-overflow-scrolling: touch; }
 .we-sidebar-col { position: sticky; top: var(--wp--custom--layout--sticky-top); align-self: flex-start; max-height: calc(100vh - var(--wp--custom--layout--sticky-top)); overflow-y: auto; border-right: 1px solid var(--wp--custom--border--subtle); padding: 20px 0 48px 0; margin: 0; }

--- a/docs/architecture/phase-3-css-necessity-map.md
+++ b/docs/architecture/phase-3-css-necessity-map.md
@@ -33,7 +33,7 @@ gate for #94 is therefore:
 | **token-value** | hard-coded constant a preset/custom-prop should own | **in-band** — the `112px` sticky offset promoted to `theme.json` |
 | **component visual system** | badges, callouts, chips, cards, stats, ability-table, nav skins | **deferred → v0.5 phase 6** (register as block styles; audit row 16) |
 | **light/dark token redefinition** | `[data-theme]` blocks re-declaring `--wp--preset--*` | **deferred → #97 / Phase 4** (rows 8/9; gated) |
-| **content-width** | `.we-content-col` width / `wideSize` | **`.we-content-col` fixed width RESOLVED by #103** (removed; content-col fills, `theme.json` `contentSize` governs); docs-band `wideSize` / remaining constants → #95 follow-up |
+| **content-width** | `.we-content-col` width / `wideSize` | **`.we-content-col` fixed width RESOLVED by #103** (hardcoded `800px !important` removed; the content column now tracks `theme.json` `contentSize` via `--wp--style--global--content-size`, and the docs band tracks it too); docs-band `wideSize` / remaining constants → #95 follow-up |
 | **plugin-integration** | FluentCart / WooCommerce CSS | **n/a — none in the base stylesheet** (§5) |
 
 ## 3. What changed this phase

--- a/docs/architecture/phase-3-css-necessity-map.md
+++ b/docs/architecture/phase-3-css-necessity-map.md
@@ -33,7 +33,7 @@ gate for #94 is therefore:
 | **token-value** | hard-coded constant a preset/custom-prop should own | **in-band** — the `112px` sticky offset promoted to `theme.json` |
 | **component visual system** | badges, callouts, chips, cards, stats, ability-table, nav skins | **deferred → v0.5 phase 6** (register as block styles; audit row 16) |
 | **light/dark token redefinition** | `[data-theme]` blocks re-declaring `--wp--preset--*` | **deferred → #97 / Phase 4** (rows 8/9; gated) |
-| **content-width** | `.we-content-col` width / `wideSize` | **deferred → #95 / Phase 4** |
+| **content-width** | `.we-content-col` width / `wideSize` | **`.we-content-col` fixed width RESOLVED by #103** (removed; content-col fills, `theme.json` `contentSize` governs); docs-band `wideSize` / remaining constants → #95 follow-up |
 | **plugin-integration** | FluentCart / WooCommerce CSS | **n/a — none in the base stylesheet** (§5) |
 
 ## 3. What changed this phase

--- a/docs/architecture/phase-4-content-width.md
+++ b/docs/architecture/phase-4-content-width.md
@@ -1,0 +1,113 @@
+# Phase 4 (slice 1) — content-width 832 (issue #95)
+
+> **Branch:** `v0.4-content-width` · **Date:** 2026-06-02 · Light/dark (#97) and v0.5 out.
+> **Locked target:** docs 3-column middle column = **832px (52rem)** on desktop, **single-sourced
+> in `theme.json` `settings.layout.contentSize`**, user-editable via Site Editor → Styles →
+> Layout → **Content width**; the `.we-content-col { 800px !important }` CSS authority removed.
+> **Outcome:** achieved natively + **Playground-measured**; the readable docs column is now a pure
+> function of `contentSize` (proven: editing it 832→600 moves the column to 600). No deploy.
+
+---
+
+## 1. Target reconciliation (REFERENCE was stale)
+
+The `REFERENCE — Claude Code Docs Layout Specification` measured **598–721px** — **superseded**.
+Issue #95 **locks 832px (52rem)** as the docs content width, matching current code.claude.com/docs
++ hermes-agent docs; the prototype + live knowledge site are corrected *toward* 832 (the
+prototype is wrong on this dimension). 832 is an **interim** value — cheap to change now that it
+is single-sourced.
+
+## 2. Native mechanism (Handbook)
+
+`Settings/Layout.md`: `settings.layout.contentSize` is the default content width; a block with a
+**constrained** layout and **"Inner blocks use content width"** (no explicit `contentSize`)
+**inherits** it. WordPress emits it as the `--wp--style--global--content-size` CSS var, and the
+Site Editor **Content width** control edits `settings.layout.contentSize`. So the native path to
+"editable content width governing the docs column" is: **`post-content` constrained, inheriting
+`contentSize`** — exactly what the issue specifies ("the middle column must inherit this via a
+constrained layout — not a hardcoded flex-basis/max-width").
+
+## 3. What the investigation found (Playground, playwright computed widths)
+
+**Baseline (current `main`, contentSize 800, `.we-content-col {800!important}`):** the middle
+column **actually rendered 740, readable text 644** — *not* 800. The `800` was a never-reached
+cap: the docs band (`.we-page-columns`) is capped at the template `main` `wideSize` (1200), so the
+fixed-basis columns **flex-shrank** to fit (sidebar 260→210, toc 240→249, content 800→740).
+
+**Rejected approach — fix the column to the content-size var (`flex-basis/max-width:
+var(--…--content-size); flex-shrink:0`):** gave readable text = 832, but the column became 928
+(832 + 96 padding), overflowing the band → **sidebar/toc shrank to 179/221** (regression). A
+fixed middle also **squished** the sidebars on < ~1500 screens. Wrong: it re-hardcodes a width.
+
+**Chosen approach — content-col *fills*, `post-content` constrained inherit governs:** remove the
+`.we-content-col` width entirely (it fills via the core column default); the readable width is
+capped by `post-content`'s constrained `contentSize` (832). The fixed sidebars (260/240) are
+preserved (the flexible content-col absorbs the slack); the band is widened so 832 can be reached.
+
+## 4. The changes (4 files, value = single-source)
+
+| File | Change |
+|---|---|
+| `theme.json` | `settings.layout.contentSize` **800 → 832** (the single source; `wideSize` stays 1140 site-default). |
+| `assets/css/theme.css` | `.we-content-col` loses `flex-basis:800!important; max-width:800!important; flex-grow:0!important` → **`{ padding: 20px 48px 80px }`** only. The column now fills; no hardcoded width, no `!important`. |
+| `templates/single-post.html` | `post-content` `contentSize:"800px"` → **inherit** (`{type:constrained}`); docs band `main` `wideSize` **1200 → 1500** (per-template) so the 3-col band can fit an 832 readable column alongside the 260 sidebar + 240 toc (+ their padding). |
+| `templates/front-page-knowledge.html` | `post-content` `contentSize:"800px"` → **inherit**. Its 2-col band (`wideSize` 1200) already fits 832 (no toc), so no `wideSize` change. |
+
+`wideSize` decision (#95): the **site default** `wideSize` stays `1140` in `theme.json`; the docs
+band width is a **per-template** `wideSize` (single-post 1500), which the spec explicitly sanctions
+("per-template constrained-layout setting, still native"). Non-docs/blog templates untouched.
+
+## 5. Playground evidence (computed widths, playwright/chromium)
+
+**single-post (docs), contentSize 832, wideSize 1500 — readable text caps at 832:**
+
+| viewport | readable | sidebar | toc | note |
+|---|---|---|---|---|
+| 1920 | **832** | 261 | 296 | full 3-col, capped at contentSize |
+| 1600 | **832** | 261 | 296 | capped at contentSize |
+| 1440 | 675 | 261 | 296 | graceful (band viewport-limited) |
+| 1280 | **832** | 261 | hidden | toc hides `@≤1280`, content fills |
+| 1000 | **832** | hidden | hidden | sidebar hides `@≤1024` |
+| 600 | 508 | hidden | hidden | stacked, fills (`<832`) |
+
+Readable **never exceeds 832** (the `contentSize` cap) and degrades gracefully; sidebar/toc keep
+their intended 260/240 (un-shrunk).
+
+**Editability — the control governs it (decisive):** setting `contentSize` **600px** moved the
+readable column to **exactly 600** (was 832) with sidebar/toc unchanged. The readable docs column
+is a pure function of `settings.layout.contentSize`, which is what the Site Editor Content-width
+control edits.
+
+## 6. Regression scope (intended single-source consequence)
+
+`contentSize` is the **site default**, so changing 800→832 widens every template whose
+`post-content` *inherits* it: the docs (single-post, front-page-knowledge → 832 via the band) **and
+`index.html` + `page.html`** (their `post-content {constrained}` → 832, was 800). **Blog templates
+keep their explicit widths** (`single-post-blog` 680, `page-series` 520/680, `category-blog` 680) —
+unaffected. This is the deliberate single-source tradeoff: one editable default (832) for all
+non-blog content. If index/page must stay 800, give them an explicit `contentSize` (still native) —
+flagged for the design pass.
+
+## 7. Honest caveats (for the design pass)
+
+- **832 needs a wide viewport.** With the current sidebar (260) + toc (240, +56 own padding) +
+  content padding (96) overhead (~653px), the 3-col band must be ≥ ~1485px for the readable column
+  to reach 832 — i.e. **~1600px viewport**. Below that the column is narrower (graceful). On a
+  1440 laptop it is ~675. If 832 is wanted at 1440, the *design pass* must narrow the
+  sidebars/padding — out of scope here. (832 is interim per the issue.)
+- **`wideSize 1500` bounds the control's upper range.** The docs band caps how wide the
+  Content-width control can push the readable column (~847 at wideSize 1500); pushing `contentSize`
+  far above 832 would also need the docs `wideSize` raised. The control governs the realistic range
+  (and any decrease) fully — proven.
+- **Toc-visible mid-range dip (1281–1599):** with the toc shown but the band viewport-limited, the
+  readable column is < 832 (e.g. 675 @1440), recovering to 832 at ≥1600. Inherent to a fixed-toc +
+  flexible-content layout; readable is ≥ the old baseline (644) everywhere.
+
+## 8. Verification summary (task checklist)
+
+- visual parity **except the intended wider docs column** ✓ (readable 644→832 on wide; sidebar/toc
+  preserved; responsive breakpoints intact).
+- Site Editor **Content width control governs** the docs column ✓ (contentSize 600 → readable 600).
+- no regression elsewhere ✓ (blog explicit widths unaffected; index/page widen 800→832 by design).
+- **Deploy-gated:** verified in ephemeral Playground (no live mutation). Effective live check is a
+  post-deploy `design-snapshot` + `render-page` compare when authorized.

--- a/docs/architecture/phase-4-content-width.md
+++ b/docs/architecture/phase-4-content-width.md
@@ -108,6 +108,7 @@ flagged for the design pass.
 - visual parity **except the intended wider docs column** ✓ (readable 644→832 on wide; sidebar/toc
   preserved; responsive breakpoints intact).
 - Site Editor **Content width control governs** the docs column ✓ (contentSize 600 → readable 600).
-- no regression elsewhere ✓ (blog explicit widths unaffected; index/page widen 800→832 by design).
+- no **unexpected** regression elsewhere ✓ (blog explicit widths unaffected; index/page widen
+  800→832 by **deliberate site-default choice** — see §6).
 - **Deploy-gated:** verified in ephemeral Playground (no live mutation). Effective live check is a
   post-deploy `design-snapshot` + `render-page` compare when authorized.

--- a/docs/architecture/phase-4-content-width.md
+++ b/docs/architecture/phase-4-content-width.md
@@ -57,9 +57,10 @@ tracks `contentSize`.** Two parts:
    flex-grow: 0` (WP generates that var from `theme.json` `layout.contentSize`). The column is now
    832, token-driven, not a hardcoded `800px`.
 2. The centred docs band is sized to **exactly** the column sum so there is no slack (no gap) and it
-   still tracks the token: `.we-page-columns--3col { width: calc(653px + var(--…--content-size)) }`
-   (overhead 653 = sidebar 261 incl. 1px border + toc 296 incl. padding + content padding 96);
-   `--2col` (front page, no toc) = `calc(357px + var)`. `max-width:100%` + default `flex-shrink`
+   still tracks the token: `.we-page-columns--3col { width: calc(var(--wp--custom--layout--docs-band-chrome-3-col) + var(--…--content-size)) }`.
+   The fixed "chrome" is a **theme.json token** (`settings.custom.layout.docsBandChrome3Col = 653px`
+   = sidebar 261 incl. 1px border + toc 296 incl. padding + content padding 96), and
+   `docsBandChrome2Col = 357px` (front page, no toc). `max-width:100%` + default `flex-shrink`
    keep it graceful on narrow viewports. Editing `contentSize` resizes the column **and** the band
    together, so proportions never break and no gap opens.
 
@@ -71,8 +72,8 @@ is deterministic.)
 
 | File | Change |
 |---|---|
-| `theme.json` | `settings.layout.contentSize` **800 → 832** (the single source; `wideSize` stays 1140 site-default). |
-| `assets/css/theme.css` | `.we-content-col` width pointed at the token: `flex-basis/max-width: var(--wp--style--global--content-size); flex-grow:0` (was `800px !important`). `.we-page-columns` becomes a centred container (`max-width:100%; margin-inline:auto`) with `--3col`/`--2col` modifiers carrying the contentSize-tracking `width: calc(<overhead> + var)`. |
+| `theme.json` | `settings.layout.contentSize` **800 → 832** (the single source). `settings.custom.layout` gains **`docsBandChrome3Col: 653px`** + **`docsBandChrome2Col: 357px`** (emit `--wp--custom--layout--docs-band-chrome-3-col` / `…-2-col`) so the band-chrome constants live in theme.json, not as CSS magic numbers. |
+| `assets/css/theme.css` | `.we-content-col` width pointed at the token: `flex-basis/max-width: var(--wp--style--global--content-size); flex-grow:0` (was `800px !important`). `.we-page-columns` becomes a centred container (`max-width:100%; margin-inline:auto`) with `--3col`/`--2col` modifiers carrying `width: calc(var(--…--docs-band-chrome-{3,2}-col) + var(--…--content-size))`. |
 | `templates/single-post.html` | `post-content` `contentSize:"800px"` → **inherit**; columns block gains the `we-page-columns--3col` modifier; docs band `main` `wideSize` reverted **1500 → 1200** (the band is governed by the calc, not `wideSize`). |
 | `templates/front-page-knowledge.html` | `post-content` `contentSize:"800px"` → **inherit**; columns block gains the `we-page-columns--2col` modifier (2-col band, no toc). |
 
@@ -98,6 +99,12 @@ no gap.
 readable column to **exactly 700** *and* the band to **1353** (= calc(653+700)), with **sidebar 261 /
 toc 296 unchanged and gap 0**. So the Site-Editor Content-width control resizes the column and the
 band together — proportions hold, no gap.
+
+**front-page-knowledge (2-col, rendered — not "by construction"):** seeded a static knowledge front
+page (`we_enable_knowledge_frontpage=1`, sidebar menu assigned) and rendered `/`. `@1920` & `@1440`:
+band **1189** (= calc(357+832)), sidebar **261**, no toc, readable **832**, **right-edge gap 0**.
+Editability: `contentSize 700` → band **1057** (= calc(357+700)), readable **700**, sidebar 261,
+gap 0. The token vars resolve correctly (`--…--docs-band-chrome-3-col = 653px`, `…-2-col = 357px`).
 
 **Baseline comparison (origin/main, same rich content):** `@1920` readable 644 / sidebar 210 / toc
 249 (band capped at 1200, all flex-shrunk); `@1280` sidebar **122** — i.e. **identical** to this

--- a/docs/architecture/phase-4-content-width.md
+++ b/docs/architecture/phase-4-content-width.md
@@ -4,8 +4,18 @@
 > **Locked target:** docs 3-column middle column = **832px (52rem)** on desktop, **single-sourced
 > in `theme.json` `settings.layout.contentSize`**, user-editable via Site Editor → Styles →
 > Layout → **Content width**; the `.we-content-col { 800px !important }` CSS authority removed.
-> **Outcome:** achieved natively + **Playground-measured**; the readable docs column is now a pure
-> function of `contentSize` (proven: editing it 832→600 moves the column to 600). No deploy.
+> **Outcome:** the docs middle column is a token-driven width (832) and the centred band **tracks
+> `contentSize`** so the Site Editor Content-width control governs it with **no TOC-edge gap**
+> (Playground-measured with realistic content; editing contentSize 832→700 moves column + band,
+> proportions intact). No deploy.
+>
+> **Correction (2026-06-03):** the first version of this slice (PR #103, deploy-tested) made the
+> content-col **fill** (`flex-grow:1`) and relied on `post-content` constrained to cap the readable
+> text. That **regressed the live 3-column layout** — `contentSize` sizes only the *constrained
+> content inside* a flex column, not the column itself, so the flex columns redistributed (sidebar
+> too wide, middle under-sized, TOC right-edge gap). The isolation harness (empty Hello-World post)
+> masked it; re-verified with a rich post + sidebar menu + computed-width gap measurement. §3–§5
+> document the **corrected** fix.
 
 ---
 
@@ -34,49 +44,64 @@ column **actually rendered 740, readable text 644** — *not* 800. The `800` was
 cap: the docs band (`.we-page-columns`) is capped at the template `main` `wideSize` (1200), so the
 fixed-basis columns **flex-shrank** to fit (sidebar 260→210, toc 240→249, content 800→740).
 
-**Rejected approach — fix the column to the content-size var (`flex-basis/max-width:
-var(--…--content-size); flex-shrink:0`):** gave readable text = 832, but the column became 928
-(832 + 96 padding), overflowing the band → **sidebar/toc shrank to 179/221** (regression). A
-fixed middle also **squished** the sidebars on < ~1500 screens. Wrong: it re-hardcodes a width.
+**Regressed approach (PR #103) — content-col *fills* (`flex-grow:1`), `post-content` constrained
+caps the readable text.** With an empty post this *measured* fine, but on live (real content) it
+broke: a filling flex column with the readable text centred inside leaves whitespace between the
+text and the TOC (the "TOC right-edge gap"), and the redistribution made the sidebar too wide and
+the middle under-sized. Root cause: **`contentSize` does not size a flex column** — it caps the
+*constrained content inside* it. So the column needs its own width authority.
 
-**Chosen approach — content-col *fills*, `post-content` constrained inherit governs:** remove the
-`.we-content-col` width entirely (it fills via the core column default); the readable width is
-capped by `post-content`'s constrained `contentSize` (832). The fixed sidebars (260/240) are
-preserved (the flexible content-col absorbs the slack); the band is widened so 832 can be reached.
+**Corrected approach — the column keeps a width authority pointed at the token, and the band
+tracks `contentSize`.** Two parts:
+1. `.we-content-col` regains a width: `flex-basis/max-width: var(--wp--style--global--content-size);
+   flex-grow: 0` (WP generates that var from `theme.json` `layout.contentSize`). The column is now
+   832, token-driven, not a hardcoded `800px`.
+2. The centred docs band is sized to **exactly** the column sum so there is no slack (no gap) and it
+   still tracks the token: `.we-page-columns--3col { width: calc(653px + var(--…--content-size)) }`
+   (overhead 653 = sidebar 261 incl. 1px border + toc 296 incl. padding + content padding 96);
+   `--2col` (front page, no toc) = `calc(357px + var)`. `max-width:100%` + default `flex-shrink`
+   keep it graceful on narrow viewports. Editing `contentSize` resizes the column **and** the band
+   together, so proportions never break and no gap opens.
 
-## 4. The changes (4 files, value = single-source)
+(Earlier rejected idea — `width: fit-content` on the band — failed: flex intrinsic sizing summed the
+columns' *content* widths, not their flex-basis, shrinking everything wrongly. The explicit `calc`
+is deterministic.)
+
+## 4. The changes (4 files)
 
 | File | Change |
 |---|---|
 | `theme.json` | `settings.layout.contentSize` **800 → 832** (the single source; `wideSize` stays 1140 site-default). |
-| `assets/css/theme.css` | `.we-content-col` loses `flex-basis:800!important; max-width:800!important; flex-grow:0!important` → **`{ padding: 20px 48px 80px }`** only. The column now fills; no hardcoded width, no `!important`. |
-| `templates/single-post.html` | `post-content` `contentSize:"800px"` → **inherit** (`{type:constrained}`); docs band `main` `wideSize` **1200 → 1500** (per-template) so the 3-col band can fit an 832 readable column alongside the 260 sidebar + 240 toc (+ their padding). |
-| `templates/front-page-knowledge.html` | `post-content` `contentSize:"800px"` → **inherit**. Its 2-col band (`wideSize` 1200) already fits 832 (no toc), so no `wideSize` change. |
+| `assets/css/theme.css` | `.we-content-col` width pointed at the token: `flex-basis/max-width: var(--wp--style--global--content-size); flex-grow:0` (was `800px !important`). `.we-page-columns` becomes a centred container (`max-width:100%; margin-inline:auto`) with `--3col`/`--2col` modifiers carrying the contentSize-tracking `width: calc(<overhead> + var)`. |
+| `templates/single-post.html` | `post-content` `contentSize:"800px"` → **inherit**; columns block gains the `we-page-columns--3col` modifier; docs band `main` `wideSize` reverted **1500 → 1200** (the band is governed by the calc, not `wideSize`). |
+| `templates/front-page-knowledge.html` | `post-content` `contentSize:"800px"` → **inherit**; columns block gains the `we-page-columns--2col` modifier (2-col band, no toc). |
 
-`wideSize` decision (#95): the **site default** `wideSize` stays `1140` in `theme.json`; the docs
-band width is a **per-template** `wideSize` (single-post 1500), which the spec explicitly sanctions
-("per-template constrained-layout setting, still native"). Non-docs/blog templates untouched.
+`wideSize` decision (#95): the docs band is no longer governed by `main` `wideSize` (it's the
+`calc`-tracked band); `wideSize` is left at the original `1200` per template and `1140` site-default.
 
-## 5. Playground evidence (computed widths, playwright/chromium)
+## 5. Playground evidence (computed widths, playwright/chromium, **rich content** — post with H2/H3 + sidebar menu)
 
-**single-post (docs), contentSize 832, wideSize 1500 — readable text caps at 832:**
+**single-post (docs 3-col), contentSize 832:**
 
-| viewport | readable | sidebar | toc | note |
-|---|---|---|---|---|
-| 1920 | **832** | 261 | 296 | full 3-col, capped at contentSize |
-| 1600 | **832** | 261 | 296 | capped at contentSize |
-| 1440 | 675 | 261 | 296 | graceful (band viewport-limited) |
-| 1280 | **832** | 261 | hidden | toc hides `@≤1280`, content fills |
-| 1000 | **832** | hidden | hidden | sidebar hides `@≤1024` |
-| 600 | 508 | hidden | hidden | stacked, fills (`<832`) |
+| viewport | readable | sidebar | toc | TOC-edge gap | note |
+|---|---|---|---|---|---|
+| 1920 | **832** | 261 | 296 | **0** | full 3-col, band 1485 = calc(653+832) |
+| 1600 | **832** | 261 | 296 | **0** | band 1485 |
+| 1440 | 734 | 230 | 268 | **0** | graceful (band viewport-limited, proportional) |
+| 1280 | (toc hides) | 122* | — | — | `@≤1280` toc hides, content fills — *sidebar 122 is **pre-existing**, see §7 |
 
-Readable **never exceeds 832** (the `contentSize` cap) and degrades gracefully; sidebar/toc keep
-their intended 260/240 (un-shrunk).
+Wide-desktop: readable **= 832**, sidebar/toc at their **intended** widths (261/296, un-shrunk), and
+the TOC-edge **gap = 0** (the #103 regression). Below the band width it shrinks proportionally with
+no gap.
 
-**Editability — the control governs it (decisive):** setting `contentSize` **600px** moved the
-readable column to **exactly 600** (was 832) with sidebar/toc unchanged. The readable docs column
-is a pure function of `settings.layout.contentSize`, which is what the Site Editor Content-width
-control edits.
+**Editability — the control governs it (decisive):** setting `contentSize` **700px** moved the
+readable column to **exactly 700** *and* the band to **1353** (= calc(653+700)), with **sidebar 261 /
+toc 296 unchanged and gap 0**. So the Site-Editor Content-width control resizes the column and the
+band together — proportions hold, no gap.
+
+**Baseline comparison (origin/main, same rich content):** `@1920` readable 644 / sidebar 210 / toc
+249 (band capped at 1200, all flex-shrunk); `@1280` sidebar **122** — i.e. **identical** to this
+branch at 1280, confirming that squish is pre-existing (§7).
 
 ## 6. Regression scope (intended single-source consequence)
 
@@ -90,25 +115,31 @@ flagged for the design pass.
 
 ## 7. Honest caveats (for the design pass)
 
-- **832 needs a wide viewport.** With the current sidebar (260) + toc (240, +56 own padding) +
-  content padding (96) overhead (~653px), the 3-col band must be ≥ ~1485px for the readable column
-  to reach 832 — i.e. **~1600px viewport**. Below that the column is narrower (graceful). On a
-  1440 laptop it is ~675. If 832 is wanted at 1440, the *design pass* must narrow the
-  sidebars/padding — out of scope here. (832 is interim per the issue.)
-- **`wideSize 1500` bounds the control's upper range.** The docs band caps how wide the
-  Content-width control can push the readable column (~847 at wideSize 1500); pushing `contentSize`
-  far above 832 would also need the docs `wideSize` raised. The control governs the realistic range
-  (and any decrease) fully — proven.
-- **Toc-visible mid-range dip (1281–1599):** with the toc shown but the band viewport-limited, the
-  readable column is < 832 (e.g. 675 @1440), recovering to 832 at ≥1600. Inherent to a fixed-toc +
-  flexible-content layout; readable is ≥ the old baseline (644) everywhere.
+- **832 needs a wide viewport.** The overhead (sidebar 261 + toc 296 + content padding 96 = 653)
+  means the 3-col band must be ≥ ~1485px for the column to reach 832 — i.e. **~1600px viewport**.
+  Below that the band is viewport-limited and the whole band shrinks **proportionally with no gap**
+  (e.g. @1440 readable 734). If 832 is wanted at 1440, the *design pass* must narrow the
+  sidebars/padding — out of scope. (832 is interim per the issue.)
+- **The `calc` overhead (653 / 357) is a hardcoded constant.** It encodes the fixed chrome
+  (sidebar/toc/padding). If those dimensions change, update the `calc`. This is the price of a
+  centred, gap-free, contentSize-tracking band that core's constrained layout can't express for a
+  flex columns row (`fit-content` was tried and is unreliable — §3).
+- **Pre-existing `@≤1280` sidebar squish.** At the `@≤1280` breakpoint the toc hides and content
+  fills via the existing `flex-basis:auto !important` responsive rule; with **long** content the
+  content column claims its intrinsic width and the sidebar squishes (~122px). This is **measured
+  identical on `origin/main`** (§5 baseline) — it predates this slice and is **out of scope**.
+  A future pass could set the responsive content-col `min-width:0` / `flex-basis:0` to fix it.
 
 ## 8. Verification summary (task checklist)
 
-- visual parity **except the intended wider docs column** ✓ (readable 644→832 on wide; sidebar/toc
-  preserved; responsive breakpoints intact).
-- Site Editor **Content width control governs** the docs column ✓ (contentSize 600 → readable 600).
+- **3-column layout verified in full** (rich post + sidebar menu, computed widths) — the #103
+  regression is gone: wide-desktop readable **832**, sidebar **261** / toc **296** at intended
+  widths, **TOC-edge gap 0**; graceful proportional shrink below; responsive breakpoints intact.
+- **Editing contentSize moves the column AND keeps proportions** ✓ (contentSize 700 → readable 700,
+  band 1353, sidebar/toc unchanged, gap 0) — the Site-Editor Content-width control governs it.
+- **`@≤1280` sidebar squish is pre-existing** (origin/main measured identical) — not introduced here.
 - no **unexpected** regression elsewhere ✓ (blog explicit widths unaffected; index/page widen
   800→832 by **deliberate site-default choice** — see §6).
-- **Deploy-gated:** verified in ephemeral Playground (no live mutation). Effective live check is a
-  post-deploy `design-snapshot` + `render-page` compare when authorized.
+- **Deploy-gated:** verified in ephemeral Playground (no live mutation). The live regression that
+  rolled back #103 is reproduced-then-fixed here; a post-deploy `render-page`/computed-width check on
+  the docs layout (with real content) is the gate before re-deploy.

--- a/templates/front-page-knowledge.html
+++ b/templates/front-page-knowledge.html
@@ -19,7 +19,7 @@
 <!-- wp:column {"className":"we-content-col"} -->
 <div class="wp-block-column we-content-col">
 
-<!-- wp:post-content {"layout":{"type":"constrained","contentSize":"800px"}} /-->
+<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
 
 </div>
 <!-- /wp:column -->

--- a/templates/front-page-knowledge.html
+++ b/templates/front-page-knowledge.html
@@ -7,8 +7,8 @@
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained","wideSize":"1200px"},"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|70"}}}} -->
 <main class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--70)">
 
-<!-- wp:columns {"className":"we-page-columns","style":{"spacing":{"blockGap":{"left":"0"}}}} -->
-<div class="wp-block-columns we-page-columns">
+<!-- wp:columns {"className":"we-page-columns we-page-columns--2col","style":{"spacing":{"blockGap":{"left":"0"}}}} -->
+<div class="wp-block-columns we-page-columns we-page-columns--2col">
 
 <!-- wp:column {"width":"260px","className":"we-sidebar-col"} -->
 <div class="wp-block-column we-sidebar-col" style="flex-basis:260px">

--- a/templates/single-post.html
+++ b/templates/single-post.html
@@ -4,11 +4,11 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:group {"tagName":"main","layout":{"type":"constrained","wideSize":"1500px"},"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|70"}}}} -->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained","wideSize":"1200px"},"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|70"}}}} -->
 <main class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--70)">
 
-<!-- wp:columns {"className":"we-page-columns","style":{"spacing":{"blockGap":{"left":"0"}}}} -->
-<div class="wp-block-columns we-page-columns">
+<!-- wp:columns {"className":"we-page-columns we-page-columns--3col","style":{"spacing":{"blockGap":{"left":"0"}}}} -->
+<div class="wp-block-columns we-page-columns we-page-columns--3col">
 
 <!-- wp:column {"width":"260px","className":"we-sidebar-col"} -->
 <div class="wp-block-column we-sidebar-col" style="flex-basis:260px">

--- a/templates/single-post.html
+++ b/templates/single-post.html
@@ -4,7 +4,7 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:group {"tagName":"main","layout":{"type":"constrained","wideSize":"1200px"},"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|70"}}}} -->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained","wideSize":"1500px"},"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|70"}}}} -->
 <main class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--70)">
 
 <!-- wp:columns {"className":"we-page-columns","style":{"spacing":{"blockGap":{"left":"0"}}}} -->
@@ -55,7 +55,7 @@
 </div>
 <!-- /wp:group -->
 
-<!-- wp:post-content {"layout":{"type":"constrained","contentSize":"800px"}} /-->
+<!-- wp:post-content {"layout":{"type":"constrained"}} /-->
 
 <!-- wp:separator {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|40"}}}} -->
 <hr class="wp-block-separator has-alpha-channel-opacity" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--40)"/>

--- a/theme.json
+++ b/theme.json
@@ -4,7 +4,7 @@
     "settings": {
         "appearanceTools": true,
         "useRootPaddingAwareAlignments": true,
-        "layout": { "contentSize": "800px", "wideSize": "1140px" },
+        "layout": { "contentSize": "832px", "wideSize": "1140px" },
         "color": {
             "defaultPalette": false, "defaultGradients": false,
             "palette": [

--- a/theme.json
+++ b/theme.json
@@ -94,7 +94,7 @@
             "lineHeight": { "tight": "1.03", "heading": "1.12", "body": "1.82", "loose": "1.9" },
             "letterSpacing": { "tight": "-0.045em", "heading": "-0.03em", "label": "0.1em" },
             "radius": { "card": "8px", "segment": "12px", "terminal": "14px", "pill": "100px" },
-            "layout": { "stickyTop": "112px" }
+            "layout": { "stickyTop": "112px", "docsBandChrome3Col": "653px", "docsBandChrome2Col": "357px" }
         }
     },
     "styles": {


### PR DESCRIPTION
Phase 4 slice 1 (issue #95). Light/dark (#97) and v0.5 out. Investigated + verified with the Handbook and **Playground (playwright computed-width measurement, realistic content)**; no live deploy.

> **History:** the first version of this PR made the content column *fill* and relied on `post-content` constrained to cap the readable text. That **regressed the live 3-column layout** (`contentSize` sizes only the constrained content *inside* a flex column, not the column) and was rolled back. This PR is the corrected, token-driven fix, re-verified with rich content.

## Outcome
The docs middle column is **832px (52rem)**, **single-sourced in `theme.json` `settings.layout.contentSize`**, and **user-editable in Site Editor → Styles → Layout → Content width** — the `.we-content-col { 800px !important }` authority is gone, and the centred docs band **tracks contentSize** so editing it keeps proportions with **no TOC-edge gap**.

## Mechanism
- **Column width = the token:** `.we-content-col { flex-basis/max-width: var(--wp--style--global--content-size); flex-grow: 0 }` (WP generates that var from `theme.json` `layout.contentSize`).
- **Band tracks contentSize** (centred, no slack): `.we-page-columns--{3,2}col { width: calc(var(--wp--custom--layout--docs-band-chrome-{3,2}-col) + var(--…--content-size)) }`. The band-chrome is a **theme.json token** — `settings.custom.layout.docsBandChrome3Col = 653px` (sidebar 261 + toc 296 + content padding 96), `docsBandChrome2Col = 357px` (front page, no toc).

## Changes
- `theme.json`: `contentSize` **800 → 832**; `custom.layout.docsBandChrome3Col/2Col` added.
- `theme.css`: `.we-content-col` → token-driven width (was `800px !important`); `.we-page-columns` centred + `--3col`/`--2col` calc band.
- `single-post.html` / `front-page-knowledge.html`: `post-content` `800` → **inherit**; columns get the `--3col` / `--2col` modifier. **`wideSize` unchanged (1200)** — the band is the calc now.

## Playground evidence (rich content: post w/ H2/H3 + assigned sidebar menu)
**single-post 3-col @1920/1600:** readable **832**, sidebar **261**, toc **296**, **gap 0**; @1440 graceful (734, gap 0).
**front-page-knowledge 2-col `/` @1920:** band **1189** = calc(357+832), sidebar **261**, no toc, readable **832**, **gap 0**.
**Editability:** 3-col `contentSize 700` → band **1353**, readable **700**, gap 0; 2-col `700` → band **1057**, readable **700**, gap 0. Sidebar/toc unchanged throughout.

## Regression scope (intended single-source consequence)
`index.html` + `page.html` inherit `contentSize` → they also move **800 → 832**. **Blog templates keep explicit widths** (680/520) — unaffected.

## Out of scope (recorded → follow-ups)
- **`@≤1280` sidebar squish** with long content: **pre-existing** (measured identical on `origin/main`) — separate follow-up.
- **Full primitive token model** (sidebar/TOC/padding as tokens, widths off markup, band derived): **#95 follow-up**; the band-chrome `calc` is the interim, with a sync note in the CSS.

Full root-cause + measurements: `docs/architecture/phase-4-content-width.md`. Deploy-gated (ephemeral Playground only). Draft — for Hermes/GPT-5.5. Don't merge until re-reviewed (it regressed once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
